### PR TITLE
Reformatted all pages 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,7 +8,7 @@ html, body #root {
     height: 100%;
     margin: 0;
     padding: 0;
-    overflow-y: hidden;
+    overflow-x: hidden;
 }
 
 .App {

--- a/src/App.css
+++ b/src/App.css
@@ -1,27 +1,18 @@
-html, body {
-    height: 100%;
+* {
     margin: 0;
+    padding: 0;
+    box-sizing: border-box;
 }
 
-body {
-    background-image: url('../public/built-background.png');
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;  
+html, body #root {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow-y: hidden;
 }
 
 .App {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
-}
-
-.App-main {
-    height: 100vh;
-    flex-grow: 1; 
-    display: flex;
-    flex-direction: column;
-    padding: 20px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -5,18 +5,12 @@ import GetInvolvedPage from './pages/getInvolvedPage';
 import CalendarPage from './pages/calendarPage';
 import Footer from './components/footer';
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
-import StickyNavBar from './components/stickyNavBar'
 import './App.css';
 
 function App() {
     return (
         <div className="App">
-            <Router>
-                {/*replaced nav with navbar*/ }
-
-                <StickyNavBar />
-              
-                <main className="App-main"> 
+            <Router>        
                     <Routes>
                         <Route path="/" element={<Navigate to="/Home" />} />
                         <Route path="/Home" element={<HomePage />} />
@@ -24,7 +18,6 @@ function App() {
                         <Route path="/Get-Involved" element={<GetInvolvedPage />} />
                         <Route path="/Calendar" element={<CalendarPage />} />
                     </Routes>
-                </main>
             </Router>
             <Footer/>
 

--- a/src/components/stickyNavBar.js
+++ b/src/components/stickyNavBar.js
@@ -11,7 +11,7 @@ const StickyNavBar = () => {
           <Link to="/Home" className="button">Home</Link>
           <Link to="/About" className="button">About Us</Link>
           <Link to="/Calendar" className="button">Calendar</Link>
-          <Link to="/GetInvolvedPage" className="button">Get Involved</Link>
+          <Link to="/Get-Involved" className="button">Get Involved</Link>
         </div>
       </div>
     </>

--- a/src/pages/aboutPage.js
+++ b/src/pages/aboutPage.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import StickyNavBar from '../components/stickyNavBar'
 import '../styles/aboutPage.css';
 
 function AboutPage() {
     return (
-        <div className="AboutPage">
-            <header className="AboutPage-header">
-                <h1>About Us</h1>
-                <p>Welcome to the about page!</p>
-            </header>
+        <div className="About-Page">
+            <StickyNavBar />
+            <h1>About Us</h1>
+            <p>Welcome to the about page!</p>
+          
         </div>
     );
 }

--- a/src/pages/calendarPage.js
+++ b/src/pages/calendarPage.js
@@ -1,13 +1,12 @@
 import React from 'react';
+import StickyNavBar from '../components/stickyNavBar';
 import '../styles/calendarPage.css';
 
 function CalendarPage() {
     return (
-        <div className="CalendarPage">
-            <header className="CalendarPage-header">
-                <h1>Calendar</h1>
-                <p>Welcome to the calendar page!</p>
-            </header>
+        <div className="Calendar-Page">
+            <StickyNavBar />
+            <h1>Calendar</h1>
         </div>
     );
 }

--- a/src/pages/getInvolvedPage.js
+++ b/src/pages/getInvolvedPage.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import StickyNavBar from '../components/stickyNavBar'
 import '../styles/getInvolvedPage.css';
 
 function GetInvolvedPage() {
     return (
-        <div className="GetInvolved">
-            <header className="GetInvolved-header">
-                <h1>Get Involved</h1>
-                <p>Welcome to the get involved page!</p>
-            </header>
+        <div className="Get-Involved-Page">
+            <StickyNavBar />
+            <h1>Get Involved</h1>
+            <p>Welcome to the get involved page!</p>
+          
         </div>
     );
 }

--- a/src/pages/homePage.js
+++ b/src/pages/homePage.js
@@ -1,12 +1,12 @@
 import React from 'react';
+import StickyNavBar from '../components/stickyNavBar';
 import '../styles/homePage.css';
 
 function HomePage() {
     return (
-        <div className="HomePage">
-            <header className="HomePage-header">
-                <h1>Welcome to the home page!</h1>
-            </header>
+        <div className="Home-Page">
+            <StickyNavBar />
+            <h1>Welcome to the home page!</h1> 
         </div>
     );
 }

--- a/src/styles/aboutPage.css
+++ b/src/styles/aboutPage.css
@@ -1,0 +1,11 @@
+/* Styles for the about page. */
+
+.About-Page {
+    background-color: #FFE7D7;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-position: center;
+    flex:1;
+    width: 100%;
+}

--- a/src/styles/calendarPage.css
+++ b/src/styles/calendarPage.css
@@ -1,0 +1,9 @@
+/* Styles for the calendar page */
+
+.Calendar-Page {
+    background-color: #FFE7D7;
+    display: flex;
+    flex-direction: column;
+    flex:1;
+    width: 100%;
+}

--- a/src/styles/getInvolvedPage.css
+++ b/src/styles/getInvolvedPage.css
@@ -1,0 +1,11 @@
+/* Styles for the get involved page */
+
+.Get-Involved-Page {
+    background-color: #FFE7D7;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-position: center;
+    flex:1;
+    width: 100%;
+}

--- a/src/styles/homePage.css
+++ b/src/styles/homePage.css
@@ -1,0 +1,11 @@
+/* Styles for home page */
+
+.Home-Page {
+    background-image: url("../../public/built-background.png");
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-position: center;
+    flex:1;
+    width: 100%;
+}


### PR DESCRIPTION
# Summary #32 
Previously the website had one static background for all four pages. I updated all pages of the website so that the background fits the Figma design. 

### Changes:
- Removed background and styling from `app.css`
- Added backgrounds to `homePage.css`, `aboutPage.css`, `getInvolvedPage.css`, and `calendarPage.css`
-  Removed unnecessary `header` HTML tags in all JavaScript files.
- Changed all HTML tags' `className` from "thisFormat" to "this-format".
-  Adjusted styling in `App.css` so the background could fill the entire page.
-  Removed the `stickNavigationBar` element from `App.css` and placed it in every page's JavaScript file. This is necessary in order for the sticky nav bar to display over the background, versus on top.

### Photos:
- ![image](https://github.com/user-attachments/assets/eda6374f-330f-475e-bae2-68689fbb0453)
- ![image](https://github.com/user-attachments/assets/129a15fc-7846-4008-a429-8ea979175226)
- ![image](https://github.com/user-attachments/assets/fd9ca92e-b49e-4fde-96f1-428fce5492d0)
- ![image](https://github.com/user-attachments/assets/311d8b03-c4a4-4f98-bb69-55394cbe11b9)