### PR TITLE
Fixed LinkedIn link 

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -14,7 +14,7 @@ function Footer() {
                 <a href='https://www.instagram.com/built_uiuc/' target='_blank' rel='nooopener noreffer'>
                     <img src = '/instagram-svgrepo-com.svg' alt='instagram svg' />
                 </a>
-                <a href='https://www.linkedin.com/groups/14432013/' target='_blank' rel='nooopener noreffer'>
+                <a href='https://www.linkedin.com/in/built-uiuc/' target='_blank' rel='nooopener noreffer'>
                     <img src = '/linkedin-svgrepo-com.svg' alt='linkedin svg' />
                 </a>
             </div>


### PR DESCRIPTION
# Summary
LinkedIn link in the footer needed to be updated to built's LinkedIn page instead of the LinkedIn group. 

### Changes:
- In `footer.js` fixed LinkedIn link to our LinkedIn page.

### Demo:
https://github.com/user-attachments/assets/d99a65f8-7e9b-45e8-bef0-dc3169b3930e