### PR TITLE
Welcome card's slack link

### DIFF
--- a/src/components/welcomeCard.js
+++ b/src/components/welcomeCard.js
@@ -11,7 +11,7 @@ function WelcomeCard({name, imageSrc, description}) {
                 join us in building a diverse future!
             </p>  
             <div className='icons'>
-                <a href='https://join.slack.com/t/builtuiuc/shared_invite/zt-2sf5zdr42-pyiMyNzisGl7f0PMa91Dhw' target='_blank' rel='noopener noreferrer'>
+                <a href='https://tinyurl.com/built-uiuc' target='_blank' rel='noopener noreferrer'>
                     <img src = 'slack-svgrepo-com.svg' alt='twitter svg' />
                 </a>
                 <a href='https://github.com/orgs/B-U-I-L-T-UIUC/repositories' target='_blank' rel='noopener noreferrer'>


### PR DESCRIPTION
replaced the temporary slack link that was in the Welcome Card component with the permanent one from the footer component.